### PR TITLE
Automatically retrieve a users write access token if it has not yet been set in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
+settings.yaml
 .venv
 response.json
 movies-data

--- a/src/api_call_class.py
+++ b/src/api_call_class.py
@@ -1,13 +1,9 @@
 import requests
-from dotenv import load_dotenv
-import os
 import json
-
-load_dotenv()
 
 class APICall:
     def __init__(self, token_type, endpoint, version, params, headers, data = None):
-        self.access_token = os.getenv(token_type)
+        self.access_token = token_type
         self.data = data
         self.file_path = "response.json"
         self.endpoint = endpoint

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,12 @@ import sys
 from pathlib import Path
 from movies_to_tmdb import TMDBMovieIDs, TMDBLists, TMDBCredentials
 
-TMDBCredentials.get_account_id() # Get current user account id using their access token
+config_settings = TMDBCredentials.get_config() # Get yaml config file
+
+if config_settings['tmdb_write_access_token'] is None: # Check if write access token has been set
+    TMDBCredentials.get_credentials(config_settings) # If not, then fetch the users write acccess token
+
+TMDBCredentials.get_account_id() # Get users account id once tokens and credentials have been set
 
 script_path = Path(__file__) # Get path to script
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from movies_to_tmdb import TMDBMovieIDs, TMDBLists, TMDBCredentials
 config_settings = TMDBCredentials.get_config() # Get yaml config file
 
 if config_settings['tmdb_write_access_token'] is None: # Check if write access token has been set
-    TMDBCredentials.get_credentials(config_settings) # If not, then fetch the users write acccess token
+    TMDBCredentials.get_tokens(config_settings) # If not, then fetch the users write acccess token
 
 TMDBCredentials.get_account_id() # Get users account id once tokens and credentials have been set
 

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -8,14 +8,23 @@ load_dotenv()
 
 class TMDBCredentials:
     read_access_token = "tmdb_read_access_token"
-    write_access_token = "tmdb_write_access_token"
+    write_access_token = None
     account_id = None
 
     @classmethod
     def get_account_id(cls):
-        api_call = APICall(cls.read_access_token, 'account', '3', {}, {}, None)
+        api_call = APICall(token_type=cls.read_access_token, endpoint='account', version='3', params={}, headers={})
         json_response = api_call.make_request()
         cls.account_id = json_response['id']
+
+    @classmethod
+    def get_req_token(cls):
+        api_call = APICall(token_type=cls.read_access_token, endpoint='auth/request_token', version='4', params={}, headers={})
+        response = api_call.send_data()
+        if response['success'] == True:
+            request_token = response['request_token']
+            return request_token
+        print(f"Error: {response['status_message']}")
 
 # Due to limited detail in exported letterboxd data, some manual filtering is required for rare duplicate edge cases,
 # where the name and release year are the exact same.

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -58,7 +58,14 @@ class TMDBCredentials:
         with open("settings.yaml", "w") as config_yml:
             yaml.safe_dump(config_settings, config_yml)
             print("Saved access token to yaml config file.")
-            
+
+    @classmethod
+    def get_credentials(cls, config_settings):
+        request_token = cls.get_req_token()
+        cls.approve_req_token(request_token)
+        access_token = cls.get_access_token(request_token)
+        cls.update_config(config_settings, access_token)
+
 # This class is meant to get the TMDB id's for each movie in the watched list,
 # so that we can add them to a custom TMDB list, for which we need the id of each movie.
 class TMDBMovieIDs(TMDBCredentials):

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -52,6 +52,13 @@ class TMDBCredentials:
             return access_token
         print(f"Error retrieving access token: {response['status_message']}")
 
+    @staticmethod
+    def update_config(config_settings, access_token):
+        config_settings['tmdb_write_access_token'] = access_token
+        with open("settings.yaml", "w") as config_yml:
+            yaml.safe_dump(config_settings, config_yml)
+            print("Saved access token to yaml config file.")
+            
 # This class is meant to get the TMDB id's for each movie in the watched list,
 # so that we can add them to a custom TMDB list, for which we need the id of each movie.
 class TMDBMovieIDs(TMDBCredentials):

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -15,8 +15,11 @@ class TMDBCredentials:
     def get_account_id(cls):
         api_call = APICall(token_type=cls.read_access_token, endpoint='account', version='3', params={}, headers={})
         json_response = api_call.make_request()
-        cls.account_id = json_response['id']
-
+        if 'id' in json_response:
+            cls.account_id = json_response['id']
+            return
+        print("Error. Could not retrieve account id.")
+    
     @classmethod
     def get_req_token(cls):
         api_call = APICall(token_type=cls.read_access_token, endpoint='auth/request_token', version='4', params={}, headers={})

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -64,6 +64,7 @@ class TMDBCredentials:
         request_token = cls.get_req_token()
         cls.approve_req_token(request_token)
         access_token = cls.get_access_token(request_token)
+        cls.write_access_token = access_token
         cls.update_config(config_settings, access_token)
 
 # This class is meant to get the TMDB id's for each movie in the watched list,

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -208,4 +208,4 @@ class TMDBLists(TMDBCredentials):
             print(f"Movies successfully added to {list_name.title()}!")
             return
         status_msg = json_response['status_message']
-        print(f"Error: {status_msg}")
+        print(f"Error adding movies to {list_name} list: {status_msg}")

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -25,6 +25,16 @@ class TMDBCredentials:
             print(f"Successfully retrived account id: {cls.account_id}")
             return
         print("Error. Could not retrieve account id.")
+    
+    @classmethod
+    def get_req_token(cls):
+        api_call = APICall(cls.read_access_token, endpoint="auth/request_token", version='4', params={}, headers={})
+        response = api_call.send_data()
+        if response['success'] == True:
+            request_token = response['request_token']
+            print("Successfully retrieved request token")
+            return request_token
+        print(f"Error: {response['status_message']}")
 
 # This class is meant to get the TMDB id's for each movie in the watched list,
 # so that we can add them to a custom TMDB list, for which we need the id of each movie.

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -60,7 +60,7 @@ class TMDBCredentials:
             print("Saved access token to yaml config file.")
 
     @classmethod
-    def get_credentials(cls, config_settings):
+    def get_tokens(cls, config_settings):
         request_token = cls.get_req_token()
         cls.approve_req_token(request_token)
         access_token = cls.get_access_token(request_token)

--- a/src/movies_to_tmdb.py
+++ b/src/movies_to_tmdb.py
@@ -34,7 +34,23 @@ class TMDBCredentials:
             request_token = response['request_token']
             print("Successfully retrieved request token")
             return request_token
-        print(f"Error: {response['status_message']}")
+        print(f"Error retrieving request token: {response['status_message']}")
+
+    @classmethod
+    def approve_req_token(cls, request_token):
+        print(f"Approve your request token by visiting: https://www.themoviedb.org/auth/access?request_token={request_token}")
+        input("Press enter when finished to continue:")
+
+    @classmethod
+    def get_access_token(cls, request_token):
+        payload = {"request_token": request_token}
+        api_call = APICall(cls.read_access_token, "auth/access_token", '4', {}, {}, data=payload)
+        response = api_call.send_data()
+        if response['success'] == True:
+            access_token = response['access_token']
+            print("Successfully retrieved access token")
+            return access_token
+        print(f"Error retrieving access token: {response['status_message']}")
 
 # This class is meant to get the TMDB id's for each movie in the watched list,
 # so that we can add them to a custom TMDB list, for which we need the id of each movie.


### PR DESCRIPTION
This adds the needed methods and functionality to the TMDBCredentials class to automatically fetch a users write access token if it has not already been set. Quick overview of key changes and additions:

- Changed config file from .env to .yaml for increased flexibility and integration with code
- Added get_config method in Credentials class to load .yaml file into environment
- Created get_req_token method to fetch a user's request token
- Created approve_req_token to have user approve the token and validate it 
- Created get_access_token method to fetch user's access token after request token has been approved
- Created update_config method to add access token to yaml file and update it
- Created get_tokens orchestrator method to call all token related methods
- Updated main script to use get_tokens method if write access token has not been set in yaml file